### PR TITLE
Fixes proxy support for gaxios

### DIFF
--- a/integration.js
+++ b/integration.js
@@ -24,9 +24,13 @@ function startup(logger) {
     ...(typeof rejectUnauthorized === 'boolean' && { rejectUnauthorized })
   });
 
+  if(_configFieldIsValid(proxy)){
+    process.env.HTTP_PROXY = proxy;
+    process.env.HTTPS_PROXY = proxy;
+  }
+
   gaxios.instance.defaults = {
-    agent: httpsAgent,
-    ...(_configFieldIsValid(proxy) && { proxy: { host: proxy } })
+    agent: httpsAgent
   };
 }
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "main": "./integration.js",
   "name": "intsights",
-  "version": "3.0.1-beta",
+  "version": "3.0.3-beta",
   "private": true,
   "dependencies": {
     "async": "^3.2.0",


### PR DESCRIPTION
Fixes proxy setup when using gaxios.  Per this issue https://github.com/googleapis/gaxios/issues/378, the proxy needs to be set as an environment variable (this is actually good for us as it should make it easier to set the proxy programmatically from the UI).